### PR TITLE
add linked devices functionality for pigeon

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/DeviceLinkFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/DeviceLinkFragment.java
@@ -6,11 +6,17 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
+
+import pigeon.components.Mp02CustomDialog;
+
+import static pigeon.extensions.BuildExtensionsKt.isPigeonVersion;
+import static pigeon.extensions.BuildExtensionsKt.isSignalVersion;
 
 public class DeviceLinkFragment extends Fragment implements View.OnClickListener {
 
@@ -18,16 +24,26 @@ public class DeviceLinkFragment extends Fragment implements View.OnClickListener
   private LinkClickedListener linkClickedListener;
   private Uri                 uri;
 
+  private EditText mUuidInput;
+  private EditText mPubKeyInput;
+
   @Override
   public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup viewGroup, Bundle bundle) {
     this.container = (LinearLayout) inflater.inflate(R.layout.device_link_fragment, container, false);
     this.container.findViewById(R.id.link_device).setOnClickListener(this);
-    ViewCompat.setTransitionName(container.findViewById(R.id.devices), "devices");
+    if (isSignalVersion()) {
+      ViewCompat.setTransitionName(container.findViewById(R.id.devices), "devices");
 
-    if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      container.setOrientation(LinearLayout.HORIZONTAL);
-    } else {
-      container.setOrientation(LinearLayout.VERTICAL);
+      if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        container.setOrientation(LinearLayout.HORIZONTAL);
+      } else {
+        container.setOrientation(LinearLayout.VERTICAL);
+      }
+    }
+
+    if (isPigeonVersion()) {
+      mUuidInput   = container.findViewById(R.id.device_uuid_input);
+      mPubKeyInput = container.findViewById(R.id.device_pubkey_input);
     }
 
     return this.container;
@@ -51,7 +67,25 @@ public class DeviceLinkFragment extends Fragment implements View.OnClickListener
   @Override
   public void onClick(View v) {
     if (linkClickedListener != null) {
-      linkClickedListener.onLink(uri);
+      if (isSignalVersion())
+        linkClickedListener.onLink(uri);
+
+      if (isPigeonVersion()) {
+        final String titleText   = getString(R.string.DeviceProvisioningActivity_link_this_device);
+        final String introText   = getString(R.string.DeviceProvisioningActivity_content_intro);
+        final String contentText = getString(R.string.DeviceProvisioningActivity_content_bullets);
+
+        Mp02CustomDialog dialog = new Mp02CustomDialog(requireContext());
+        dialog.setMessage(titleText + '\n' + introText + '\n' + contentText);
+        dialog.setNegativeListener(android.R.string.no, null);
+        dialog.setPositiveListener(android.R.string.yes, () -> {
+          final String uuid   = mUuidInput.getText().toString();
+          final String pubKey = mPubKeyInput.getText().toString();
+          final String qrLink = String.format("linkdevice?uuid=%s&pub_key=%s", uuid, pubKey);
+          linkClickedListener.onLink(uri != null ? uri : Uri.parse(qrLink));
+        });
+        dialog.show();
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -12,6 +12,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -35,6 +36,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
+import pigeon.components.Mp02CustomDialog;
+
+import static pigeon.extensions.BuildExtensionsKt.isPigeonVersion;
+import static pigeon.extensions.BuildExtensionsKt.isSignalVersion;
+
 public class DeviceListFragment extends ListFragment
     implements LoaderManager.LoaderCallbacks<List<Device>>,
                ListView.OnItemClickListener, Button.OnClickListener
@@ -48,6 +54,9 @@ public class DeviceListFragment extends ListFragment
   private View                        progressContainer;
   private FloatingActionButton        addDeviceButton;
   private Button.OnClickListener      addDeviceButtonListener;
+
+  private TextView mAddDeviceView;
+  private View.OnClickListener mAddDeviceViewListener;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -65,10 +74,18 @@ public class DeviceListFragment extends ListFragment
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle bundle) {
     View view = inflater.inflate(R.layout.device_list_fragment, container, false);
 
-    this.empty             = view.findViewById(R.id.empty);
     this.progressContainer = view.findViewById(R.id.progress_container);
-    this.addDeviceButton   = view.findViewById(R.id.add_device);
-    this.addDeviceButton.setOnClickListener(this);
+
+    if (isSignalVersion()) {
+      this.empty             = view.findViewById(R.id.empty);
+      this.addDeviceButton   = view.findViewById(R.id.add_device);
+      this.addDeviceButton.setOnClickListener(this);
+    }
+
+    if (isPigeonVersion()) {
+      this.mAddDeviceView     = view.findViewById(R.id.link_device_nav);
+      this.mAddDeviceView.setOnClickListener(this);
+    }
 
     return view;
   }
@@ -84,11 +101,15 @@ public class DeviceListFragment extends ListFragment
     this.addDeviceButtonListener = listener;
   }
 
+  public void setAddDeviceViewListener(View.OnClickListener listener) {
+    this.mAddDeviceViewListener = listener;
+  }
+
   @Override
   public @NonNull Loader<List<Device>> onCreateLoader(int id, Bundle args) {
-    empty.setVisibility(View.GONE);
+    if (isSignalVersion())
+      empty.setVisibility(View.GONE);
     progressContainer.setVisibility(View.VISIBLE);
-
     return new DeviceListLoader(getActivity(), accountManager);
   }
 
@@ -103,11 +124,13 @@ public class DeviceListFragment extends ListFragment
 
     setListAdapter(new DeviceListAdapter(getActivity(), R.layout.device_list_item_view, data, locale));
 
-    if (data.isEmpty()) {
-      empty.setVisibility(View.VISIBLE);
-      TextSecurePreferences.setMultiDevice(getActivity(), false);
-    } else {
-      empty.setVisibility(View.GONE);
+    if (isSignalVersion()) {
+      if (data.isEmpty()) {
+        empty.setVisibility(View.VISIBLE);
+        TextSecurePreferences.setMultiDevice(getActivity(), false);
+      } else {
+        empty.setVisibility(View.GONE);
+      }
     }
   }
 
@@ -121,24 +144,59 @@ public class DeviceListFragment extends ListFragment
     final String deviceName = ((DeviceListItem)view).getDeviceName();
     final long   deviceId   = ((DeviceListItem)view).getDeviceId();
 
-    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(requireActivity());
-    builder.setTitle(getString(R.string.DeviceListActivity_unlink_s, deviceName));
-    builder.setMessage(R.string.DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive);
-    builder.setNegativeButton(android.R.string.cancel, null);
-    builder.setPositiveButton(android.R.string.ok, (dialog, which) -> handleDisconnectDevice(deviceId));
-    builder.show();
+    if (isSignalVersion()) {
+      AlertDialog.Builder builder = new MaterialAlertDialogBuilder(requireActivity());
+      builder.setTitle(getString(R.string.DeviceListActivity_unlink_s, deviceName));
+      builder.setMessage(R.string.DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive);
+      builder.setNegativeButton(android.R.string.cancel, null);
+      builder.setPositiveButton(android.R.string.ok, (dialog, which) -> handleDisconnectDevice(deviceId));
+      builder.show();
+    }
+
+    if (isPigeonVersion()) {
+      final String titleText = getString(R.string.DeviceListActivity_unlink_s, deviceName);
+      final String bodyText  = getString(R.string.DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive);
+
+      Mp02CustomDialog dialog = new Mp02CustomDialog(requireContext());
+      dialog.setMessage(titleText + '\n' + bodyText);
+      dialog.setNegativeListener(android.R.string.cancel, null);
+      dialog.setPositiveListener(android.R.string.ok, () -> {
+        handleDisconnectDevice(deviceId);
+        dialog.dismiss();
+      });
+      dialog.show();
+    }
   }
 
   private void handleLoaderFailed() {
-    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(requireActivity());
-    builder.setMessage(R.string.DeviceListActivity_network_connection_failed);
-    builder.setPositiveButton(R.string.DeviceListActivity_try_again,
-        (dialog, which) -> getLoaderManager().restartLoader(0, null, DeviceListFragment.this));
+    if (isSignalVersion()) {
+      AlertDialog.Builder builder = new MaterialAlertDialogBuilder(requireActivity());
+      builder.setMessage(R.string.DeviceListActivity_network_connection_failed);
+      builder.setPositiveButton(R.string.DeviceListActivity_try_again,
+          (dialog, which) -> getLoaderManager().restartLoader(0, null, DeviceListFragment.this));
 
-    builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> requireActivity().onBackPressed());
-    builder.setOnCancelListener(dialog -> requireActivity().onBackPressed());
+      builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> requireActivity().onBackPressed());
+      builder.setOnCancelListener(dialog -> requireActivity().onBackPressed());
 
-    builder.show();
+      builder.show();
+    }
+
+    if (isPigeonVersion()) {
+      Mp02CustomDialog dialog = new Mp02CustomDialog(requireContext());
+      dialog.setMessage(getString(R.string.DeviceListActivity_network_failed));
+      dialog.setPositiveListener(R.string.DeviceListActivity_try_again, () -> {
+        getLoaderManager().restartLoader(0, null, DeviceListFragment.this);
+      });
+
+      dialog.setNegativeListener(android.R.string.cancel, () -> {
+        requireActivity().onBackPressed();
+      });
+      dialog.setBackKeyListener(() -> {
+        requireActivity().onBackPressed();
+      });
+
+      dialog.show();
+    }
   }
 
   @SuppressLint("StaticFieldLeak")
@@ -172,7 +230,11 @@ public class DeviceListFragment extends ListFragment
 
   @Override
   public void onClick(View v) {
-    if (addDeviceButtonListener != null) addDeviceButtonListener.onClick(v);
+    if (isSignalVersion())
+      if (addDeviceButtonListener != null) addDeviceButtonListener.onClick(v);
+
+    if (isPigeonVersion())
+      if (mAddDeviceViewListener != null) mAddDeviceViewListener.onClick(v);
   }
 
   private static class DeviceListAdapter extends ArrayAdapter<Device> {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
@@ -61,6 +61,13 @@ class AppSettingsFragment : DSLSettingsFragment(R.string.text_secure_normal__men
       )
 
       clickPref(
+        title = DSLSettingsText.from(R.string.preferences__linked_devices),
+        onClick = {
+          Navigation.findNavController(requireView()).navigate(R.id.action_appSettingsFragment_to_deviceActivity)
+        }
+      )
+
+      clickPref(
         title = DSLSettingsText.from(R.string.AccountSettingsFragment__account),
         onClick = {
           findNavController().safeNavigate(R.id.action_appSettingsFragment_to_accountSettingsFragment)
@@ -108,15 +115,6 @@ class AppSettingsFragment : DSLSettingsFragment(R.string.text_secure_normal__men
           Navigation.findNavController(requireView()).navigate(R.id.action_appSettingsFragment_to_aboutFragment)
         }
       )
-
-      if (isSignalVersion()) {
-        clickPref(
-          title = DSLSettingsText.from(R.string.preferences__linked_devices),
-          onClick = {
-            findNavController().safeNavigate(R.id.action_appSettingsFragment_to_deviceActivity)
-          }
-        )
-      }
     }
   }
 

--- a/app/src/main/res/layout-small/device_link_fragment.xml
+++ b/app/src/main/res/layout-small/device_link_fragment.xml
@@ -1,0 +1,69 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginTop="10dp"
+    android:orientation="vertical"
+    style="@style/Mp02.Signal.Background">
+
+    <TextView
+        android:id="@+id/device_uuid_label"
+        style="@style/Mp02.Signal.Text.CommonTextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusable="false"
+        android:clickable="false"
+        android:layout_marginStart="@dimen/pigeon_start_margin"
+        android:text="UUID" />
+
+    <EditText
+        android:id="@+id/device_uuid_input"
+        style="@style/Mp02.Signal.Text.CommonTextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/pigeon_start_margin"
+        android:layout_marginTop="@dimen/pigeon_bottom_margin"
+        android:backgroundTint="@color/transparent"
+        android:textColor="@color/white_focus"
+        android:nextFocusUp="@id/device_uuid_input"
+        android:nextFocusDown="@id/device_pubkey_input"
+        android:inputType="text|textNoSuggestions"
+        tools:text="uuid" />
+
+    <TextView
+        android:id="@+id/device_pubkey_label"
+        style="@style/Mp02.Signal.Text.CommonTextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusable="false"
+        android:clickable="false"
+        android:layout_marginStart="@dimen/pigeon_start_margin"
+        android:layout_marginTop="@dimen/pigeon_bottom_margin"
+        android:text="Pub Key" />
+
+    <EditText
+        android:id="@+id/device_pubkey_input"
+        style="@style/Mp02.Signal.Text.CommonTextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/pigeon_start_margin"
+        android:layout_marginTop="@dimen/pigeon_bottom_margin"
+        android:backgroundTint="@color/transparent"
+        android:textColor="@color/white_focus"
+        android:nextFocusUp="@id/device_uuid_input"
+        android:nextFocusDown="@id/link_device"
+        android:inputType="text|textNoSuggestions"
+        tools:text="pub_key" />
+
+    <org.thoughtcrime.securesms.util.views.CircularProgressMaterialButton
+        android:id="@+id/link_device"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/pigeon_bottom_margin"
+        android:nextFocusUp="@id/device_pubkey_input"
+        android:nextFocusDown="@id/link_device"
+        android:visibility="visible"
+        app:circularProgressMaterialButton__label="@string/device_link_fragment__link_device" />
+
+</LinearLayout>

--- a/app/src/main/res/layout-small/device_list_fragment.xml
+++ b/app/src/main/res/layout-small/device_list_fragment.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:viewBindingIgnore="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    style="@style/Mp02.Signal.Background">
+
+    <FrameLayout
+        android:id="@+id/progress_container"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:visibility="gone">
+
+        <ProgressBar
+            style="?android:attr/progressBarStyleLargeInverse"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_gravity="center"
+            android:indeterminate="true"
+            android:indeterminateTint="@color/white"
+            android:progressTint="@color/white"
+            android:padding="10dp" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/link_device_nav"
+        style="@style/Mp02.Signal.Text.CommonTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="50dp"
+        android:text="@string/device_list_fragment__link_new_device" />
+
+    <ListView android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="5dp"
+        android:divider="@color/white_not_focus"
+        android:dividerHeight="1sp"
+        android:listSelector="@drawable/listview_background_selector"
+        tools:listitem="@layout/device_list_item_view" />
+
+    <TextView
+        android:id="@android:id/empty"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_marginTop="15dp"
+        android:gravity="center_horizontal"
+        android:text="@string/device_list_fragment__no_devices_linked"
+        android:textAppearance="@style/TextAppearance.Signal.Body2"
+        android:textColor="@color/white_not_focus" />
+
+</LinearLayout>

--- a/app/src/main/res/layout-small/device_list_item_view.xml
+++ b/app/src/main/res/layout-small/device_list_item_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.DeviceListItem xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:viewBindingIgnore="true"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    style="@style/Mp02.Signal.Background">
+
+    <TextView android:id="@+id/name"
+              android:textAppearance="?android:attr/textAppearanceMedium"
+              android:textColor="@color/mp02_listview_color_selector"
+              android:singleLine="true"
+              android:ellipsize="marquee"
+              android:layout_marginTop="8dp"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              tools:text="Desktop" />
+
+    <TextView android:id="@+id/created"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:textAppearance="?android:attr/textAppearanceSmall"
+              android:textColor="@color/mp02_listview_color_selector"
+              android:fontFamily="sans-serif-light"
+              tools:text="Linked 2 July" />
+
+    <TextView android:id="@+id/active"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:textAppearance="?android:attr/textAppearanceSmall"
+              android:textColor="@color/mp02_listview_color_selector"
+              android:fontFamily="sans-serif-light"
+              android:layout_marginBottom="8dp"
+              tools:text="Last active Wed" />
+
+</org.thoughtcrime.securesms.DeviceListItem>


### PR DESCRIPTION
Add support for linking Pigeon to other devices.

This implementation prompts the user for the QR code's uuid and pub key url parameters. The user will have to get this from decoding the QR code on their desktop or mobile. The Pigeon User Manual would need updating to help guide the user on this process.

Tested on a 2.7" Android Emulator. Requires testing with a physical MP02 device to ensure navigation works, and UX changes look right.